### PR TITLE
Fix/overlay updates

### DIFF
--- a/package/src/main.js
+++ b/package/src/main.js
@@ -32,6 +32,12 @@ export class OpenSeadragon extends React.Component {
     debugMode: false
   };
 
+  fullyLoaded = false;
+
+  id = String(Math.round(Math.random() * 1000000000));
+
+  elements = new Map();
+
   async componentDidMount() {
     const {
       tileSources,
@@ -74,10 +80,6 @@ export class OpenSeadragon extends React.Component {
 
     this.elements.clear();
   }
-
-  fullyLoaded = false;
-
-  id = String(Math.round(Math.random() * 1000000000));
 
   isFullyLoaded() {
     const {world} = this.instance;
@@ -146,7 +148,10 @@ export class OpenSeadragon extends React.Component {
       this.instance.addOverlay({element, location});
     } else {
       const homeBounds = this.instance.world.getHomeBounds();
-      this.instance.addOverlay(element, new this.OSD.Rect(0, 0, homeBounds.width, homeBounds.height));
+      this.instance.addOverlay(
+        element,
+        new this.OSD.Rect(0, 0, homeBounds.width, homeBounds.height)
+      );
     }
   }
 
@@ -158,26 +163,17 @@ export class OpenSeadragon extends React.Component {
     return new this.OSD.MouseTracker(params);
   }
 
-  elements = new Map();
+  render() {
+    const {style} = this.props;
 
-  getElement(key) {
-    const id = this.getOverlayId(key);
-    let element = this.elements.get(id);
-
-    if (element) {
-      return element;
-    }
-
-    element = document.createElement('div');
-    element.id = id;
-
-    this.elements.set(id, element);
-
-    return element;
-  }
-
-  getOverlayId(key) {
-    return `Overlay${key}`;
+    return (
+      <React.Fragment>
+        <div id={this.id} style={style} />
+        <OpenSeadragonContext.Provider value={this}>
+          {this.renderChildren()}
+        </OpenSeadragonContext.Provider>
+      </React.Fragment>
+    );
   }
 
   renderChildren() {
@@ -197,17 +193,24 @@ export class OpenSeadragon extends React.Component {
     return null;
   }
 
-  render() {
-    const {style} = this.props;
+  getElement(key) {
+    const id = this.getOverlayId(key);
+    let element = this.elements.get(id);
 
-    return (
-      <React.Fragment>
-        <div id={this.id} style={style} />
-        <OpenSeadragonContext.Provider value={this}>
-          {this.renderChildren()}
-        </OpenSeadragonContext.Provider>
-      </React.Fragment>
-    );
+    if (element) {
+      return element;
+    }
+
+    element = document.createElement('div');
+    element.id = id;
+
+    this.elements.set(id, element);
+
+    return element;
+  }
+
+  getOverlayId(key) {
+    return `Overlay${key}`;
   }
 }
 

--- a/package/src/main.js
+++ b/package/src/main.js
@@ -71,6 +71,8 @@ export class OpenSeadragon extends React.Component {
   componentWillUnmount() {
     this.instance.world.removeAllHandlers();
     this.instance.removeAllHandlers();
+
+    this.elements.clear();
   }
 
   fullyLoaded = false;
@@ -139,23 +141,13 @@ export class OpenSeadragon extends React.Component {
     }
   };
 
-  addOverlay(element, {x, y, width, height} = {}) {
-    let location;
-
-    if (x !== undefined && y !== undefined) {
-      if (width !== undefined && height !== undefined) {
-        location = new this.OSD.Rect({x, y, width, height});
-      } else {
-        location = new this.OSD.Point({x, y});
-      }
-
+  addOverlay(element, location) {
+    if (location) {
       this.instance.addOverlay({element, location});
     } else {
       const homeBounds = this.instance.world.getHomeBounds();
-      location = new this.OSD.Rect(0, 0, homeBounds.width, homeBounds.height);
+      this.instance.addOverlay(element, new this.OSD.Rect(0, 0, homeBounds.width, homeBounds.height));
     }
-
-    this.instance.addOverlay(element, location);
   }
 
   removeOverlay(element) {
@@ -166,22 +158,53 @@ export class OpenSeadragon extends React.Component {
     return new this.OSD.MouseTracker(params);
   }
 
+  elements = new Map();
+
+  getElement(key) {
+    const id = this.getOverlayId(key);
+    let element = this.elements.get(id);
+
+    if (element) {
+      return element;
+    }
+
+    element = document.createElement('div');
+    element.id = id;
+
+    this.elements.set(id, element);
+
+    return element;
+  }
+
+  getOverlayId(key) {
+    return `Overlay${key}`;
+  }
+
+  renderChildren() {
+    const {children} = this.props;
+
+    if (this.instance && children) {
+      return React.Children.map(children, child => {
+        if (child) {
+          const element = this.getElement(child.key);
+
+          element.style['pointer-events'] = 'none';
+          return ReactDOM.createPortal(React.cloneElement(child, {element}), element);
+        }
+      });
+    }
+
+    return null;
+  }
+
   render() {
-    const {style, children} = this.props;
+    const {style} = this.props;
 
     return (
       <React.Fragment>
         <div id={this.id} style={style} />
         <OpenSeadragonContext.Provider value={this}>
-          {this.instance &&
-            children &&
-            React.Children.map(children, child => {
-              if (child) {
-                const element = document.createElement('div');
-                element.style['pointer-events'] = 'none';
-                return ReactDOM.createPortal(React.cloneElement(child, {element}), element);
-              }
-            })}
+          {this.renderChildren()}
         </OpenSeadragonContext.Provider>
       </React.Fragment>
     );

--- a/package/src/overlay.js
+++ b/package/src/overlay.js
@@ -7,23 +7,34 @@ import {withOpenSeadragon} from './main';
 export class Overlay extends React.Component {
   static propTypes = {
     element: PropTypes.instanceOf(HTMLElement).isRequired,
-    x: PropTypes.number,
-    y: PropTypes.number,
-    width: PropTypes.number,
-    height: PropTypes.number,
+    location: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number,
+      width: PropTypes.number,
+      height: PropTypes.number
+    }),
     style: PropTypes.object,
     children: PropTypes.node,
     openSeadragon: PropTypes.object.isRequired
   };
 
   componentDidMount() {
-    const {openSeadragon, element, x, y, width, height, style} = this.props;
+    const {openSeadragon, element, location, style} = this.props;
 
     if (style) {
       Object.assign(element.style, style);
     }
 
-    openSeadragon.addOverlay(element, {x, y, width, height});
+    openSeadragon.addOverlay(element, location);
+  }
+
+  componentDidUpdate(prevProps) {
+    const {openSeadragon: {instance}, element, location} = this.props;
+
+    if (location !== prevProps.location) {
+      instance.getOverlayById(element).update(location);
+      instance.forceRedraw();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Re-introduces tracking of created elements by id.

The id is based on the child's key value, which is either automatically created or specified by the user, e.g.

```javascript
<Overlay key="visualizer">
</Overlay>
```

![overlay_key](https://user-images.githubusercontent.com/274358/47270763-a66cc600-d570-11e8-99c5-43c680b09d0d.png)

The other overlays are not specifying any key and thus re-use the divs based on the positional keys generated by React, which might or might not be the previous component. 

Other changes:

- Props have been changed to accept a location object, instead of the flat values.
- The Overlay component now also checks for location updates, because openseadragon needs to be notified of these changes.